### PR TITLE
Skip `global` in Terser plugin

### DIFF
--- a/appsscript.json
+++ b/appsscript.json
@@ -34,6 +34,7 @@
   "exceptionLogging": "STACKDRIVER",
   "oauthScopes": [
     "https://www.googleapis.com/auth/gmail.send",
+    "https://www.googleapis.com/auth/userinfo.email",
     "https://www.googleapis.com/auth/drive.file",
     "https://www.googleapis.com/auth/script.external_request",
     "https://www.googleapis.com/auth/script.scriptapp",

--- a/src/index.js
+++ b/src/index.js
@@ -12,3 +12,7 @@ global.sendmail = (email = Session.getActiveUser().getEmail()) => {
   const textBody = htmlBody.replace(/<[^>]+>/g, ' ');
   GmailApp.sendEmail(email, 'Hello from Google Apps Script', textBody, { htmlBody });
 };
+
+global.onOpen = () => {
+  SpreadsheetApp.getUi().createMenu('Test').addItem('sendmail', 'sendmail').addToUi();
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -36,7 +36,9 @@ module.exports = {
         terserOptions: {
           ecma: 6,
           warnings: false,
-          mangle: {},
+          mangle: {
+            reserved: ['global']
+          },
           compress: {
             drop_console: false,
             drop_debugger: isProduction,


### PR DESCRIPTION
Terser plugin mangles variable `global` under production mode. 
This PR fixes this issue and add a spreadsheet menu example to show `global` will be alive under production mode.

![spreadsheet example](https://user-images.githubusercontent.com/389191/88755852-a1509800-d194-11ea-8db1-ec7c7faee11e.png)
