### PR TITLE
Fix dots for copy-webpack-plugin

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -66,16 +66,16 @@ module.exports = {
       patterns: [
         {
           from: getSrcPath('**/*.html'),
-          to: '[name].[ext]',
+          to: '[name][ext]',
           noErrorOnMissing: true,
         },
         {
           from: getSrcPath('../appsscript.json'),
-          to: '[name].[ext]',
+          to: '[name][ext]',
         },
         {
           from: getSrcPath('../functions/*.js'),
-          to: '[name].[ext]',
+          to: '[name][ext]',
           noErrorOnMissing: true,
         },
       ],


### PR DESCRIPTION
[copy-webpack-plugin](https://webpack.js.org/plugins/copy-webpack-plugin) doesn't require dots for extension.
